### PR TITLE
Suggestion for a more readable and less cumbersome print

### DIFF
--- a/debug_utils.h
+++ b/debug_utils.h
@@ -49,11 +49,11 @@
 	char*	: printf("[l %d] %s:%s() | " #var " = \"%s\"" _DE_NL , __LINE__, __FILE__, __FUNCTION__, var),	\
 	default	: printf("[l %d] %s:%s() | " #var " = %p" _DE_NL , __LINE__, __FILE__, __FUNCTION__, var))
 
-# define D_INT(var) printf("[l %d] %s:%s() | " #var " : %d" _DE_NL, __LINE__, __FILE__, __FUNCTION__, var);
-# define D_LINT(var) printf("[l %d] %s:%s() | " #var " : %ld" _DE_NL, __LINE__, __FILE__, __FUNCTION__, var);
-# define D_DOUB(var) printf("[l %d] %s:%s() | " #var " : %f" _DE_NL, __LINE__, __FILE__, __FUNCTION__, var);
-# define D_STR(var) printf("[l %d] %s:%s() | " #var " : \"%s\"" _DE_NL, __LINE__, __FILE__, __FUNCTION__, var);
-# define D_PTR(var) printf("[l %d] %s:%s() | " #var " : <%p>" _DE_NL, __LINE__, __FILE__, __FUNCTION__, var);
+# define D_INT(var)		printf("[%d] %-15s | %-6s : %-5d" _DE_NL, __LINE__, __FUNCTION__, #var , var);
+# define D_LINT(var)	printf("[%d] %-15s | %-6s : %-5ld" _DE_NL, __LINE__, __FUNCTION__, #var, var);
+# define D_DOUB(var)	printf("[%d] %-15s | %-6s : %-5f" _DE_NL, __LINE__, __FUNCTION__, #var, var);
+# define D_STR(var)		printf("[%d] %-15s | %-6s : \"%-5s\"" _DE_NL, __LINE__, __FUNCTION__, #var, var);
+# define D_PTR(var)		printf("[%d] %-15s | %-6s : <%-5p>" _DE_NL, __LINE__, __FUNCTION__, #var, var);
 
 # define D_STR_DETAILS(str) print_str_details(strlen(str), str, #str)
 


### PR DESCRIPTION


before :
```
[l 31] src/ft_printf.c:ft_printf() | d.min : 0
[l 32] src/ft_printf.c:ft_printf() | d.zero : 0
[l 33] src/ft_printf.c:ft_printf() | d.prec : 0
[l 34] src/ft_printf.c:ft_printf() | d.arg : 0
[l 35] src/ft_printf.c:ft_printf() | d.skip : 1
[l 36] src/ft_printf.c:ft_printf() | d.ret : 1
[l 37] src/ft_printf.c:ft_printf() | str : "test%%123"
[e#<[l 38] src/ft_printf.c:ft_printf()>#        ]
```
after:
```
[31] ft_printf       | d.min  : 0    
[32] ft_printf       | d.zero : 0    
[33] ft_printf       | d.prec : 0    
[34] ft_printf       | d.arg  : 0    
[35] ft_printf       | d.skip : 1    
[36] ft_printf       | d.ret  : 1    
[37] ft_printf       | str    : "test%%123"
#<[l 38] src/ft_printf.c:ft_printf()>#
```